### PR TITLE
Possible update to Drifting funtion

### DIFF
--- a/loggerloader/loader.py
+++ b/loggerloader/loader.py
@@ -268,6 +268,9 @@ class Drifting(object):
 
     def drift_summary(self):
         self.drift_sum_table = pd.DataFrame(self.drift_features).T
+        self.drift_sum_table['drift'] = self.drift_sum_table['drift'].astype(int)
+        self.drift_sum_table['quality'] = self.drift_sum_table['drift'] / 2
+        self.drift_sum_table.loc[(self.drift_sum_table['man_beg'].isna()) | (self.drift_sum_table['man_end'].isna()), 'quality'] = 0.3
         self.max_drift = self.drift_sum_table['drift'].abs().max()
 
     def slope_intercept(self, i):

--- a/loggerloader/loader.py
+++ b/loggerloader/loader.py
@@ -268,8 +268,8 @@ class Drifting(object):
 
     def drift_summary(self):
         self.drift_sum_table = pd.DataFrame(self.drift_features).T
-        self.drift_sum_table['drift'] = self.drift_sum_table['drift'].astype(int)
-        self.drift_sum_table['quality'] = self.drift_sum_table['drift'] / 2
+        self.drift_sum_table['drift'] = self.drift_sum_table['drift'].astype(float)
+        self.drift_sum_table['quality'] = (self.drift_sum_table['drift'] / 2).abs().round(2)
         self.drift_sum_table.loc[(self.drift_sum_table['man_beg'].isna()) | (self.drift_sum_table['man_end'].isna()), 'quality'] = 0.3
         self.max_drift = self.drift_sum_table['drift'].abs().max()
 


### PR DESCRIPTION
I updated the Drifting class in my branch of the loggerloader function to add a quality field to the drift info table that the class outputs. the quality field is either 0.30 if there weren't manual measurements or the absolute value of the drift, rounded to 2 digits.

I tested this new version of the class on two sites that each had some missing manual measurements and some drift values and it worked well.

@inkenbrandt 